### PR TITLE
Fixes to enable SNAP to link and build on mac.

### DIFF
--- a/SNAPLib/Bam.h
+++ b/SNAPLib/Bam.h
@@ -24,8 +24,8 @@ Environment:
 #include "PairedEndAligner.h"
 #include "VariableSizeVector.h"
 #include "BufferedAsync.h"
-#include "Read.h"
 #include "SAM.h"
+#include "Read.h"
 #include "DataReader.h"
 
 // for debugging file I/O, validate BAM records on input & output
@@ -408,9 +408,9 @@ public:
         static PairedReadSupplierGenerator *createPairedReadSupplierGenerator(const char *fileName, int numThreads, bool quicklyDropUnmatchedReads, 
             const ReaderContext& context, int matchBufferSize = 5000);
 
-        static const int MAX_SEQ_LENGTH = MAX_READ_LENGTH;
+        const int MAX_SEQ_LENGTH = MAX_READ_LENGTH;
 
-        static const int MAX_RECORD_LENGTH = MAX_READ_LENGTH * 8;
+        const int MAX_RECORD_LENGTH = MAX_READ_LENGTH * 8;
 
 protected:
 

--- a/SNAPLib/Compat.cpp
+++ b/SNAPLib/Compat.cpp
@@ -969,8 +969,18 @@ public:
 
     bool waitWithTimeout(_int64 timeoutInMillis) {
         struct timespec wakeTime;
+#ifdef __LINUX__
         clock_gettime(CLOCK_REALTIME, &wakeTime);
         wakeTime.tv_nsec += timeoutInMillis * 1000000;
+#elif defined(__MACH__)
+        clock_serv_t cclock;
+        mach_timespec_t mts;
+        host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+        clock_get_time(cclock, &mts);
+        mach_port_deallocate(mach_task_self(), cclock);
+        wakeTime.tv_nsec = mts.tv_nsec + timeoutInMillis * 1000000;
+        wakeTime.tv_sec = mts.tv_sec;
+#endif
         wakeTime.tv_sec += wakeTime.tv_nsec / 1000000000;
         wakeTime.tv_nsec = wakeTime.tv_nsec % 1000000000;
 


### PR DESCRIPTION
The current version of SNAP won't build on Mac. Two fixes are needed:
- Mach kernel time code is needed in both high resolution timer sections in SNAPLib/Compat.cpp
- For whatever reason, the definition of MAX_SEQ_LENGTH as static const int (instead of const int) in BAMReader causes a symbol-not-found issue during linking.
