### PR TITLE
Build fixes for *nix

### DIFF
--- a/SNAPLib/Bam.h
+++ b/SNAPLib/Bam.h
@@ -24,8 +24,8 @@ Environment:
 #include "PairedEndAligner.h"
 #include "VariableSizeVector.h"
 #include "BufferedAsync.h"
-#include "Read.h"
 #include "SAM.h"
+#include "Read.h"
 #include "DataReader.h"
 
 // for debugging file I/O, validate BAM records on input & output
@@ -408,9 +408,9 @@ public:
         static PairedReadSupplierGenerator *createPairedReadSupplierGenerator(const char *fileName, int numThreads, bool quicklyDropUnmatchedReads, 
             const ReaderContext& context, int matchBufferSize = 5000);
 
-        static const int MAX_SEQ_LENGTH = MAX_READ_LENGTH;
+        const int MAX_SEQ_LENGTH = MAX_READ_LENGTH;
 
-        static const int MAX_RECORD_LENGTH = MAX_READ_LENGTH * 8;
+        const int MAX_RECORD_LENGTH = MAX_READ_LENGTH * 8;
 
 protected:
 

--- a/SNAPLib/Compat.cpp
+++ b/SNAPLib/Compat.cpp
@@ -974,8 +974,18 @@ public:
 
     bool waitWithTimeout(_int64 timeoutInMillis) {
         struct timespec wakeTime;
+#ifdef __LINUX__
         clock_gettime(CLOCK_REALTIME, &wakeTime);
         wakeTime.tv_nsec += timeoutInMillis * 1000000;
+#elif defined(__MACH__)
+        clock_serv_t cclock;
+        mach_timespec_t mts;
+        host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+        clock_get_time(cclock, &mts);
+        mach_port_deallocate(mach_task_self(), cclock);
+        wakeTime.tv_nsec = mts.tv_nsec + timeoutInMillis * 1000000;
+        wakeTime.tv_sec = mts.tv_sec;
+#endif
         wakeTime.tv_sec += wakeTime.tv_nsec / 1000000000;
         wakeTime.tv_nsec = wakeTime.tv_nsec % 1000000000;
 
@@ -1115,6 +1125,11 @@ _uint32 InterlockedCompareExchange32AndReturnOldValue(volatile _uint32 *valueToU
 _uint64 InterlockedCompareExchange64AndReturnOldValue(volatile _uint64 *valueToUpdate, _uint64 replacementValue, _uint64 desiredPreviousValue)
 {
   return (_uint64) __sync_val_compare_and_swap((volatile _int64 *) valueToUpdate, desiredPreviousValue, replacementValue);
+}
+
+void* InterlockedCompareExchangePointerAndReturnOldValue(void * volatile *valueToUpdate, void* replacementValue, void* desiredPreviousValue)
+{
+  return __sync_val_compare_and_swap(valueToUpdate, desiredPreviousValue, replacementValue);
 }
 
 namespace {


### PR DESCRIPTION
Supersedes #27. Fixes several issues where functions were added to Windows specific code, but compatible code was not added for *nix/Mac implementations.
