### PR TITLE
allow soft-masked ambiguous characters (fixes #46)

### DIFF
--- a/SNAPLib/Compat.cpp
+++ b/SNAPLib/Compat.cpp
@@ -2055,7 +2055,7 @@ bool connectNamedPipes(NamedPipe *pipe)
 	    //
 	    // Release any exclusive lock on the toServer pipe that may have been left by a now-dead client
 	    //
-	    flock lock;
+	    struct flock lock;
 	    lock.l_type = F_UNLCK;
 	    lock.l_whence = SEEK_SET;
 	    lock.l_start = 0;
@@ -2114,7 +2114,7 @@ NamedPipe *OpenNamedPipe(const char *pipeName, bool serverSide)
 	    //
 	    // Take an exclusive lock on the toServer pipe so that only one client is sending at a time.
 	    //
-	    flock lock;
+	    struct flock lock;
 	    lock.l_type = F_WRLCK;
 	    lock.l_whence = SEEK_SET;
 	    lock.l_start = 0;

--- a/SNAPLib/DataWriter.cpp
+++ b/SNAPLib/DataWriter.cpp
@@ -315,7 +315,7 @@ AsyncDataWriter::advance(
     _ASSERT((size_t)bytes <= bufferSize - batches[current].used);
     char* data = batches[current].buffer + batches[current].used;
     size_t batchOffset = batches[current].used;
-    batches[current].used = min(bufferSize, batchOffset + bytes);
+    batches[current].used = min<long long>(bufferSize, batchOffset + bytes);
     if (filter != NULL) {
         //_int64 start = timeInNanos();
         filter->onAdvance(this, batchOffset, data, bytes, location);

--- a/SNAPLib/FASTQ.cpp
+++ b/SNAPLib/FASTQ.cpp
@@ -159,7 +159,7 @@ FASTQReader::skipPartialRecord(DataReader *data)
         char *thirdLineCandidate = secondLineCandidate;
         while (*thirdLineCandidate == 'A' || *thirdLineCandidate == 'C' || *thirdLineCandidate == 'T' || *thirdLineCandidate == 'G' ||
                 *thirdLineCandidate == 'N' || *thirdLineCandidate == 'a' || *thirdLineCandidate == 'c' || *thirdLineCandidate == 't' || 
-                *thirdLineCandidate == 'g') {
+                *thirdLineCandidate == 'g' || *thirdLineCandidate == 'n') {
             thirdLineCandidate++;
         }
 


### PR DESCRIPTION
Fixes a bug where sequences containing lowercase 'n' (perfectly valid and not uncommon) were skipped, leading to an unpaired read error.