### PR TITLE
remove SM and PL from tag from every read

### DIFF
--- a/SNAPLib/SAM.cpp
+++ b/SNAPLib/SAM.cpp
@@ -738,7 +738,7 @@ SAMFormat::getSortInfo(
 }
 
 // which @RG line fields to put in aux data of every read
-const char* FileFormat::RGLineToAux = "IDLBPLPUSM";
+const char* FileFormat::RGLineToAux = "IDLBPU";
 
     void
 FileFormat::setupReaderContext(


### PR DESCRIPTION
For fixing Issue:  Invalid SM tag in sam record #54 


Tested and qProfiler no longer errors out.

Corrections based on sam file spec:
https://samtools.github.io/hts-specs/SAMv1.pdf