### PR TITLE
Renamed Windows binary to match Linux binary (snap-aligner)

### DIFF
--- a/apps/snap/snap.vcxproj
+++ b/apps/snap/snap.vcxproj
@@ -70,21 +70,25 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)\obj\bin\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(SolutionDir)\obj\obj\snap\$(Configuration)\$(Platform)\</IntDir>
+    <TargetName>snap-aligner</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)\obj\bin\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(SolutionDir)\obj\obj\snap\$(Configuration)\$(Platform)\</IntDir>
+    <TargetName>snap-aligner</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)\obj\bin\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(SolutionDir)\obj\obj\snap\$(Configuration)\$(Platform)\</IntDir>
+    <TargetName>snap-aligner</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)\obj\bin\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>$(SolutionDir)\obj\obj\snap\$(Configuration)\$(Platform)\</IntDir>
+    <TargetName>snap-aligner</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
Renamed the Target Name to “snap-aligner” so that the Windows binary name & usage is consistent with the Linux binary.  Another potential way to do this would be to change the project name, but that would also require updating the solution file (snap.sln).  Renaming the target name seems less risky. Ref: https://github.com/mattmcloughlin/snap/commit/52d4556da88729e1b8abd3776ebf963434f09af1