### PR TITLE
remove "-msse", not needed for 64 bit systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifndef CXXFLAGS
   CXXFLAGS = -O3 -Wno-format
 endif
 
-CXXFLAGS += -MMD -ISNAPLib -msse
+CXXFLAGS += -MMD -ISNAPLib
 
 LDFLAGS += -pthread
 


### PR DESCRIPTION
Hello all,

Now that [snap-aligner is available in Debian](https://packages.debian.org/sid/snap-aligner) the automated infrastructure has been [trying to build it for every Debian platform](https://buildd.debian.org/status/package.php?p=snap-aligner&suite=unstable).

The `-msse` flag breaks the build on i386 and x32 systems and is implicit for 64 bit systems

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=812376#5

(reverses 6018b12351577e837080c1cb4c04faf54b8ad03d)
