### PR TITLE
Fix compilation errors in C++11.

### DIFF
--- a/SNAPLib/AlignerContext.cpp
+++ b/SNAPLib/AlignerContext.cpp
@@ -376,7 +376,7 @@ AlignerContext::printStats()
         (stats->filtered > 0) ? numPctAndPad(filtered, stats->filtered, 100.0 * stats->filtered / stats->totalReads, 23, strBufLen) : "",
         (stats->extraAlignments > 0) ? FormatUIntWithCommas(stats->extraAlignments, extraAlignments, strBufLen) : "",
 		isPaired() ? pctAndPad(pctPairs,  100.0 * stats->alignedAsPairs / stats->totalReads, 7, strBufLen) : "",
-		FormatUIntWithCommas((unsigned _int64)(1000 * stats->totalReads / max(alignTime, (_int64)1)), readsPerSecond, strBufLen),	// Aligntime is in ms
+		FormatUIntWithCommas((_uint64)(1000 * stats->totalReads / max(alignTime, (_int64)1)), readsPerSecond, strBufLen),	// Aligntime is in ms
 		FormatUIntWithCommas((alignTime + 500) / 1000, alignTimeString, strBufLen)
 		);
 

--- a/SNAPLib/Compat.cpp
+++ b/SNAPLib/Compat.cpp
@@ -219,7 +219,7 @@ bool WaitForEventWithTimeout(EventObject *eventObject, _int64 timeoutInMillis)
 
 void BindThreadToProcessor(unsigned processorNumber) // This hard binds a thread to a processor.  You can no-op it at some perf hit.
 {
-    if (!SetThreadAffinityMask(GetCurrentThread(),((unsigned _int64)1) << processorNumber)) {
+    if (!SetThreadAffinityMask(GetCurrentThread(),((_uint64)1) << processorNumber)) {
         WriteErrorMessage("Binding thread to processor %d failed, %d\n",processorNumber,GetLastError());
     }
 }

--- a/SNAPLib/LandauVishkin.cpp
+++ b/SNAPLib/LandauVishkin.cpp
@@ -51,7 +51,7 @@ bool writeCigar(char** o_buf, int* o_buflen, int count, char code, CigarFormat f
         }
         int written = snprintf(*o_buf, *o_buflen, "%d%c", count, code);
         if (written > *o_buflen - 1) {
-            *o_buf = '\0';
+            **o_buf = '\0';
             return false;
         } else {
             *o_buf += written;


### PR DESCRIPTION
There are two occurrences of `unsigned _int64` in the codebase, which were obviously meant to be `_uint64`.

Then there's an assignment of a `char` to a `char*`, which compiles fine with `g++ -std=c++98`, but produces a ton of meaningless errors with `g++ -std=c++11`; thankfully, `clang++` directly points out the problem.  
**I'm not sure whether that fix is correct** as to what the code was supposed to do, but it fixes compilation problems.