### PR TITLE
Fixed Makefile for building snapxl-aligner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ obj
 /SNAPCommand
 /SNAP
 /snap-aligner
+/snapxl-aligner

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ SNAPCommand: $(LIB_OBJ) $(SNAPCOMMAND_OBJ)
 
 snapxl:
 	make clean
-	make snap CXXFLAGS="-DLONG_READS $(CXXFLAGS)"
-	mv snap snapxl
+	make snap-aligner CXXFLAGS="-DLONG_READS $(CXXFLAGS)"
+	mv snap-aligner snapxl-aligner
 	make clean
 
 roc: $(LIB_OBJ) $(ROC_OBJ)


### PR DESCRIPTION
Fixed a few statements in the Makefile, and updated the .gitignore file for the new executable.