### PR TITLE
fixing off by one bug in BAM reader decodeSeqRC

### DIFF
--- a/SNAPLib/Bam.cpp
+++ b/SNAPLib/Bam.cpp
@@ -279,7 +279,8 @@ char* o_sequence,
 const _uint8* nibbles,
 int bases)
 {
-    _uint16 *o_sequence_pairs = (_uint16 *)o_sequence;
+    size_t offset = bases % 2 == 1 ? 1 : 0;
+    _uint16 *o_sequence_pairs = (_uint16 *)(o_sequence+offset);
     int pairs = bases / 2;
     for (int i = 0; i < pairs; i++) {
         o_sequence_pairs[pairs-i-1] = CodeToSeqPairRC[nibbles[i]];


### PR DESCRIPTION
If `decodeSeqRC()` receives a read with an odd number of bases, the loop will write into position `o_sequence[0]` instead of leaving it empty for the final `if` to fill it in. This commit fixes the bug by adjusting `o_sequence_pairs` to point one byte beyond the start of `o_sequence` if the read length is odd numbered.