### PR TITLE
Add missing return statement

### DIFF
--- a/SNAPLib/Compat.cpp
+++ b/SNAPLib/Compat.cpp
@@ -1119,6 +1119,7 @@ public:
     bool destroy() {
         pthread_cond_destroy(&cond);
         pthread_mutex_destroy(&lock);
+	return true;
     }
 };
 


### PR DESCRIPTION
Hi!
I was tracking down an error that occurred during the build of SNAP inside Debian:
```
    LandauVishkinTest:
    - equal strings: [OK]
    - prefixes: [OK]
    - non-equal strings: [OK]
    - overly distant strings: [OK]
    - CIGAR strings: [OK]

    EventTest:
    - many waiters: make[1]: *** [debian/rules:17: override_dh_auto_test] Segmentation fault
```
I have found that there is missing return that caused the segfault:
```
SNAPLib/Compat.cpp: In member function ‘bool SingleWaiterObjectImpl::destroy()’:
SNAPLib/Compat.cpp:1122:5: warning: no return statement in function returning non-void [-Wreturn-type]
     }
     ^
```
